### PR TITLE
feat: add Return Flare v1

### DIFF
--- a/apps/conk/src/panels/DockPanel.tsx
+++ b/apps/conk/src/panels/DockPanel.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useEffect, useState } from 'react'
 import { IconDock } from '../components/Icons'
-import { fetchSentFlares, fetchClaimedDocks, fetchCastById } from '../sui/client'
+import { fetchSentFlares, fetchClaimedDocks, fetchCastById, fetchDockClaimsByCastId } from '../sui/client'
 import { getAddress } from '../sui/zklogin'
 
 interface SentFlare {
@@ -30,6 +30,7 @@ interface SentFlare {
   claimsUsed?: number
   maxClaims?: number
   revenue?: number
+  claimedAt?: number
 }
 
 interface ClaimedDock {
@@ -52,6 +53,8 @@ export function DockPanel() {
   const [claimed, setClaimed]     = useState<ClaimedDock[]>([])
   const [loading, setLoading]     = useState(true)
   const [expandedId, setExpandedId] = useState<string|null>(null)
+  const [returningId, setReturningId] = useState<string|null>(null)
+  const [returnStatus, setReturnStatus] = useState<Record<string, string>>({})
 
   useEffect(() => {
     loadDockData()
@@ -105,6 +108,7 @@ export function DockPanel() {
       let claimsUsed = 0
       let maxClaims = 1
       let revenue = 0
+      let claimedAt = 0
 
       // Fetch live cast status
       const cast = await fetchCastById(ev.castId)
@@ -114,6 +118,14 @@ export function DockPanel() {
         if (cast.burned) status = 'burned'
         else if (cast.isDockFull) { status = 'claimed'; revenue = Math.floor(cast.feePaid * 0.97) * claimsUsed }
         else if (!cast.isLighthouse && cast.expiresAt < now) status = 'expired'
+      }
+
+      if (claimsUsed > 0) {
+        const claims = await fetchDockClaimsByCastId(ev.castId)
+        claimedAt = claims
+          .map(c => c.claimedAt)
+          .filter(Boolean)
+          .sort((a, b) => b - a)[0] ?? 0
       }
 
       enrichedSent.push({
@@ -129,6 +141,7 @@ export function DockPanel() {
         claimsUsed,
         maxClaims,
         revenue,
+        claimedAt,
       })
     }
     setSent(enrichedSent)
@@ -187,6 +200,50 @@ export function DockPanel() {
     burned:  'BURNED',
   }
 
+  const RETURN_FLARE_WINDOW_MS = 48 * 60 * 60 * 1000
+
+  function returnFlareEligibility(f: SentFlare): { ok: boolean; label: string } {
+    if (!f.recipient) return { ok: false, label: 'missing recipient email' }
+    if ((f.claimsUsed ?? 0) <= 0 || !f.claimedAt) return { ok: false, label: 'not claimed yet' }
+    const remaining = RETURN_FLARE_WINDOW_MS - (Date.now() - f.claimedAt)
+    if (remaining <= 0) return { ok: false, label: '48h window closed' }
+    const hours = Math.ceil(remaining / 3_600_000)
+    return { ok: true, label: `${hours}h left` }
+  }
+
+  async function sendReturnFlare(f: SentFlare) {
+    const eligibility = returnFlareEligibility(f)
+    if (!eligibility.ok) {
+      setReturnStatus(s => ({ ...s, [f.castId]: eligibility.label }))
+      return
+    }
+
+    setReturningId(f.castId)
+    setReturnStatus(s => ({ ...s, [f.castId]: 'sending…' }))
+    try {
+      const res = await fetch('https://conk-zkproxy-v2.italktonumbers.workers.dev/return-flare', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to:        f.recipient,
+          hook:      f.hook,
+          castId:    f.castId,
+          amount:    (f.price ?? 0) / 1_000_000,
+          claimedAt: f.claimedAt,
+        }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => null)
+        throw new Error(err?.error ?? `Return Flare failed (${res.status})`)
+      }
+      setReturnStatus(s => ({ ...s, [f.castId]: 'Return Flare sent' }))
+    } catch (err: any) {
+      setReturnStatus(s => ({ ...s, [f.castId]: err?.message ?? 'Return Flare failed' }))
+    } finally {
+      setReturningId(null)
+    }
+  }
+
   return (
     <div data-testid="dock-panel" style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
 
@@ -230,7 +287,9 @@ export function DockPanel() {
                 </div>
               </div>
             )}
-            {sent.map(f => (
+            {sent.map(f => {
+              const eligibility = returnFlareEligibility(f)
+              return (
               <div key={f.castId} onClick={() => setExpandedId(expandedId === f.castId ? null : f.castId)} style={{
                 padding: '12px', marginBottom: '8px',
                 background: 'var(--surface)', border: expandedId === f.castId ? '1px solid var(--teal)' : '1px solid var(--border2)',
@@ -253,19 +312,42 @@ export function DockPanel() {
                 <div style={{ fontSize: '14px', color: 'var(--text)', marginBottom: '6px', wordBreak: 'break-word' }}>
                   {f.hook}
                 </div>
-                <div style={{ display: 'flex', gap: '16px', fontFamily: 'var(--font-mono)', fontSize: '9px', color: 'var(--text-off)' }}>
+                <div style={{ display: 'flex', gap: '16px', fontFamily: 'var(--font-mono)', fontSize: '9px', color: 'var(--text-off)', flexWrap: 'wrap' }}>
                   {f.recipient && <span>To: {f.recipient}</span>}
                   <span>Price: ${((f.price ?? 0) / 1_000_000).toFixed(2)}</span>
                   <span>Dock: {f.claimsUsed ?? 0}/{f.maxClaims ?? 1}</span>
+                  {f.claimedAt ? <span>Claimed: {formatTime(f.claimedAt)}</span> : null}
                   {(f.revenue ?? 0) > 0 && <span style={{ color: 'var(--teal)' }}>Earned: ${((f.revenue ?? 0) / 1_000_000).toFixed(2)}</span>}
                 </div>
-                {expandedId === f.castId && f.body && (
-                  <div style={{ marginTop: '10px', padding: '12px', background: 'var(--surface2)', borderRadius: 'var(--radius)', fontSize: '13px', color: 'var(--text-dim)', lineHeight: 1.7, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                    {f.body}
+                {expandedId === f.castId && (
+                  <div onClick={e => e.stopPropagation()} style={{ marginTop: '10px' }}>
+                    {f.body && (
+                      <div style={{ padding: '12px', background: 'var(--surface2)', borderRadius: 'var(--radius)', fontSize: '13px', color: 'var(--text-dim)', lineHeight: 1.7, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: '10px' }}>
+                        {f.body}
+                      </div>
+                    )}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                      <button
+                        onClick={() => sendReturnFlare(f)}
+                        disabled={!eligibility.ok || returningId === f.castId}
+                        style={{
+                          padding: '7px 11px', borderRadius: 'var(--radius)',
+                          border: `1px solid ${eligibility.ok ? 'var(--teal)' : 'var(--border)'}`,
+                          background: eligibility.ok ? 'rgba(0,184,230,0.08)' : 'var(--surface2)',
+                          color: eligibility.ok ? 'var(--teal)' : 'var(--text-off)',
+                          fontFamily: 'var(--font-mono)', fontSize: '10px', cursor: eligibility.ok ? 'pointer' : 'not-allowed',
+                          letterSpacing: '0.04em',
+                        }}>
+                        {returningId === f.castId ? 'Sending…' : 'Return Flare'}
+                      </button>
+                      <span style={{ fontFamily: 'var(--font-mono)', fontSize: '9px', color: eligibility.ok ? 'var(--teal)' : 'var(--text-off)' }}>
+                        {returnStatus[f.castId] ?? eligibility.label}
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>
-            ))}
+            )})}
           </>
         )}
 

--- a/apps/conk/src/sui/client.ts
+++ b/apps/conk/src/sui/client.ts
@@ -444,27 +444,55 @@ export async function fetchSentFlares(authorAddress: string): Promise<Array<{
   }
 }
 
+export interface DockClaimEvent {
+  castId:     string
+  claimsUsed: number
+  maxClaims:  number
+  claimedAt:  number
+  sender:     string
+}
+
+function mapDockClaimEvent(e: any): DockClaimEvent {
+  return {
+    castId:     e.parsedJson.cast_id,
+    claimsUsed: Number(e.parsedJson.claims_used ?? 0),
+    maxClaims:  Number(e.parsedJson.max_claims ?? 0),
+    claimedAt:  Number(e.parsedJson.claimed_at ?? 0),
+    sender:     e.sender ?? '',
+  }
+}
+
+async function fetchDockClaimEvents(): Promise<DockClaimEvent[]> {
+  const events = await rpc('suix_queryEvents', [
+    { MoveEventType: `${PACKAGE}::cast::DockClaimed` },
+    null, 50, true,
+  ])
+  if (!events?.data) return []
+  return events.data.map(mapDockClaimEvent)
+}
+
 // ── Query Docks claimed by a reader ───────────────────────────
 // Returns DockClaimed events where sender = readerAddress
 export async function fetchClaimedDocks(readerAddress: string): Promise<Array<{
   castId: string; claimsUsed: number; maxClaims: number; claimedAt: number
 }>> {
   try {
-    const events = await rpc('suix_queryEvents', [
-      { MoveEventType: `${PACKAGE}::cast::DockClaimed` },
-      null, 50, true,
-    ])
-    if (!events?.data) return []
-    return events.data
-      .filter((e: any) => e.sender === readerAddress)
-      .map((e: any) => ({
-        castId:     e.parsedJson.cast_id,
-        claimsUsed: Number(e.parsedJson.claims_used ?? 0),
-        maxClaims:  Number(e.parsedJson.max_claims ?? 0),
-        claimedAt:  Number(e.parsedJson.claimed_at ?? 0),
-      }))
+    return (await fetchDockClaimEvents())
+      .filter((e) => e.sender === readerAddress)
+      .map(({ castId, claimsUsed, maxClaims, claimedAt }) => ({ castId, claimsUsed, maxClaims, claimedAt }))
   } catch (err) {
     console.error('[fetchClaimedDocks] failed:', err)
+    return []
+  }
+}
+
+// ── Query claim events for a specific cast ────────────────────
+// Author-side Return Flare uses this to enforce the 48h window.
+export async function fetchDockClaimsByCastId(castId: string): Promise<DockClaimEvent[]> {
+  try {
+    return (await fetchDockClaimEvents()).filter((e) => e.castId === castId)
+  } catch (err) {
+    console.error('[fetchDockClaimsByCastId] failed:', err)
     return []
   }
 }

--- a/zkproxy-worker/worker.js
+++ b/zkproxy-worker/worker.js
@@ -57,6 +57,15 @@ function errResponse(message, status, origin) {
   return jsonResponse({ error: message }, status, origin)
 }
 
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 // ─── Rate limiter ─────────────────────────────────────────────────────────────
 
 async function checkRateLimit(kv, key, max) {
@@ -294,6 +303,60 @@ export default {
           status:  resp.status,
           headers: { ...corsHeaders(origin), 'Content-Type': 'application/json' },
         })
+      }
+
+      // ── Return Flare email delivery ───────────────────────────────────────
+      // Must sit before generic /flare handler: /return-flare includes "flare".
+      if (path.includes('return-flare') && request.method === 'POST') {
+        const apiKey = env.RESEND_API_KEY
+        if (!apiKey) return errResponse('RESEND_API_KEY not configured', 503, origin)
+
+        let data
+        try { data = JSON.parse(rawBody) } catch { return errResponse('Bad JSON', 400, origin) }
+
+        const { to, hook, castId, amount, note, claimedAt } = data
+        if (!to || !hook || !castId) return errResponse('Missing fields', 400, origin)
+
+        const amountLabel = Number(amount || 0) > 0
+          ? `$${Number(amount).toFixed(3)} USDC`
+          : 'the original read amount'
+        const claimedLabel = Number(claimedAt || 0) > 0
+          ? new Date(Number(claimedAt)).toUTCString()
+          : 'recently'
+
+        const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><style>
+          body{background:#000208;color:#a8ccdc;font-family:monospace;margin:0;padding:32px}
+          .card{background:#020b18;border:1px solid rgba(0,212,255,0.2);padding:28px 32px;max-width:560px;margin:0 auto}
+          .label{font-size:11px;letter-spacing:0.3em;text-transform:uppercase;color:rgba(0,212,255,0.5);margin-bottom:8px}
+          .hook{font-size:22px;font-weight:700;color:#d0eef8;margin-bottom:16px;line-height:1.3}
+          .body{font-size:14px;color:rgba(168,204,220,0.7);line-height:1.8;margin-bottom:24px;white-space:pre-wrap}
+          .pill{display:inline-block;border:1px solid rgba(0,212,255,0.35);color:#00d4ff;padding:8px 12px;border-radius:999px;font-size:12px;margin-bottom:22px}
+          .footer{margin-top:24px;font-size:10px;color:rgba(168,204,220,0.25);letter-spacing:0.1em;line-height:1.8}
+        </style></head><body><div class="card">
+          <div class="label">// CONK Return Flare</div>
+          <div class="hook">${escapeHtml(hook)}</div>
+          <div class="body">The author issued a Return Flare for this cast. They intend to return ${escapeHtml(amountLabel)} from the read claimed ${escapeHtml(claimedLabel)}.</div>
+          ${note ? `<div class="body">${escapeHtml(note)}</div>` : ''}
+          <div class="pill">Return window: 48 hours</div>
+          <div class="footer">
+            Cast: ${escapeHtml(castId)}<br>
+            Powered by CONK Protocol &middot; Sui Mainnet &middot; Axiom Tide LLC<br>
+            This notification does not custody funds. Refund transfer is author-issued.
+          </div>
+        </div></body></html>`
+
+        const res = await fetch('https://api.resend.com/emails', {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ from: 'CONK Return Flare <flare@conk.app>', to: [to], subject: `Return Flare: ${hook}`, html }),
+        })
+
+        if (!res.ok) {
+          const err = await res.text().catch(() => String(res.status))
+          return errResponse(err, 502, origin)
+        }
+
+        return jsonResponse({ ok: true }, 200, origin)
       }
 
       // ── Flare email delivery ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add worker POST /return-flare route for Return Flare email notifications
- derive claimedAt from DockClaimed events by castId for the 48h return window
- add author-side Return Flare action in Dock sent-flare cards

## Verification
- npm run build
- node --check zkproxy-worker/worker.js
- git diff --check

## Notes
- No production deploy performed.
- npm run lint is currently blocked because eslint is not installed in app deps.
- npx tsc --noEmit reports existing unrelated type errors in the repo.