### PR TITLE
fix: enforce CONK revenue fees

### DIFF
--- a/apps/conk/api/cast.js
+++ b/apps/conk/api/cast.js
@@ -119,7 +119,7 @@ export default async function handler(req, res) {
     const keypair = keypairFromEnv()
     const sender = keypair.getPublicKey().toSuiAddress()
     const client = new SuiClient({ url: SUI_RPC })
-    const publishFee = input.mode === modeMap.eyes_only ? 10_000 : 1_000
+    const publishFee = input.mode === modeMap.eyes_only ? 50_000 : 1_000
     const coinId = await getUsdcCoin(client, sender, publishFee)
 
     const tx = new Transaction()

--- a/apps/conk/src/panels/DockPanel.tsx
+++ b/apps/conk/src/panels/DockPanel.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useEffect, useState } from 'react'
 import { IconDock } from '../components/Icons'
-import { fetchSentFlares, fetchClaimedDocks, fetchCastById, fetchDockClaimsByCastId } from '../sui/client'
+import { fetchSentFlares, fetchClaimedDocks, fetchCastById, fetchDockClaimsByCastId, payReturnFlareFee } from '../sui/client'
 import { getAddress } from '../sui/zklogin'
 
 interface SentFlare {
@@ -221,6 +221,10 @@ export function DockPanel() {
     setReturningId(f.castId)
     setReturnStatus(s => ({ ...s, [f.castId]: 'sending…' }))
     try {
+      setReturnStatus(s => ({ ...s, [f.castId]: 'paying $0.05 fee…' }))
+      const txDigest = await payReturnFlareFee()
+      setReturnStatus(s => ({ ...s, [f.castId]: 'sending…' }))
+
       const res = await fetch('https://conk-zkproxy-v2.italktonumbers.workers.dev/return-flare', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -230,6 +234,7 @@ export function DockPanel() {
           castId:    f.castId,
           amount:    (f.price ?? 0) / 1_000_000,
           claimedAt: f.claimedAt,
+          txDigest,
         }),
       })
       if (!res.ok) {

--- a/apps/conk/src/sui/client.ts
+++ b/apps/conk/src/sui/client.ts
@@ -516,8 +516,8 @@ export async function soundCast(opts: {
   const tx    = new Transaction()
   const coins = await getUsdcCoins(session.address)
 
-  // v6: Flares (mode 2, EYES_ONLY) require $0.01 publish fee. Non-Flares pay $0.001 baseline.
-  const publishFee = opts.mode === 2 ? 10_000 : 1_000
+  // v6: Flares (mode 2, EYES_ONLY) require $0.05 publish fee. Non-Flares pay $0.001 baseline.
+  const publishFee = opts.mode === 2 ? 50_000 : 1_000
   const [feeCoin] = tx.splitCoins(tx.object(coins[0].coinObjectId), [tx.pure.u64(publishFee)])
 
   tx.moveCall({
@@ -554,6 +554,27 @@ export async function soundCast(opts: {
   }
 
   return { digest: result.digest, castId }
+}
+
+// ── Pay Return Flare fee on-chain ─────────────────────────────
+export async function payReturnFlareFee(): Promise<string> {
+  const session = getSession()
+  if (!session) throw new Error('No session')
+
+  const { Transaction } = await import('@mysten/sui/transactions')
+  const tx    = new Transaction()
+  const coins = await getUsdcCoins(session.address)
+
+  const [feeCoin] = tx.splitCoins(tx.object(coins[0].coinObjectId), [tx.pure.u64(50_000)])
+
+  tx.moveCall({
+    target:    `${PACKAGE}::abyss::receive_return_flare`,
+    arguments: [tx.object(ABYSS), feeCoin, tx.object(CLOCK)],
+  })
+
+  tx.setSender(session.address)
+  const result = await executeTx(tx, session.address)
+  return result.digest
 }
 
 // ── Withdraw Harbor ───────────────────────────────────────────

--- a/protocol/sources/abyss.move
+++ b/protocol/sources/abyss.move
@@ -18,6 +18,7 @@ module axiom_tide::abyss {
     const FEE_CAST:     u64 = 1_000;
     const FEE_READ:     u64 = 1_000;
     const FEE_SIREN:    u64 = 30_000;
+    const FEE_RETURN_FLARE: u64 = 50_000;
     const FEE_DOCK:     u64 = 500_000;
     const FEE_LH_VISIT: u64 = 1_000;
     const FEE_LH_KILL:  u64 = 1_000_000_000_000;
@@ -79,6 +80,9 @@ module axiom_tide::abyss {
     public fun receive_siren(a: &mut Abyss, p: Coin<USDC>, c: &Clock, ctx: &TxContext) {
         deposit(a, p, FEE_SIREN,    b"siren:sound",      c, ctx);
     }
+    public fun receive_return_flare(a: &mut Abyss, p: Coin<USDC>, c: &Clock, ctx: &TxContext) {
+        deposit(a, p, FEE_RETURN_FLARE, b"return_flare:send", c, ctx);
+    }
     public fun receive_dock(a: &mut Abyss, p: Coin<USDC>, c: &Clock, ctx: &TxContext) {
         deposit(a, p, FEE_DOCK,     b"dock:open",        c, ctx);
     }
@@ -96,6 +100,7 @@ module axiom_tide::abyss {
     public fun fee_cast():     u64 { FEE_CAST }
     public fun fee_read():     u64 { FEE_READ }
     public fun fee_siren():    u64 { FEE_SIREN }
+    public fun fee_return_flare(): u64 { FEE_RETURN_FLARE }
     public fun fee_dock():     u64 { FEE_DOCK }
     public fun fee_lh_visit(): u64 { FEE_LH_VISIT }
     public fun fee_lh_kill():  u64 { FEE_LH_KILL }

--- a/protocol/sources/cast.move
+++ b/protocol/sources/cast.move
@@ -28,7 +28,7 @@ module axiom_tide::cast {
     const MIN_PAID_PRICE:    u64 = 100_000;
 
     const DOCK_SLOT_PRICE:        u64 = 10_000;
-    const MIN_FLARE_PUBLISH_FEE:  u64 = 10_000;  // v6: $0.01 minimum to send a Flare (EYES_ONLY)
+    const MIN_FLARE_PUBLISH_FEE:  u64 = 50_000;  // v6: $0.05 minimum to send a Flare (EYES_ONLY)
     const MIN_MAX_CLAIMS:    u64 = 1;
     const MAX_MAX_CLAIMS:    u64 = 10_000;
 
@@ -144,7 +144,7 @@ module axiom_tide::cast {
         let paid_amount = coin::value(&fee_coin);
         assert!(paid_amount >= dock_upgrade_fee, E_INSUFFICIENT_UPGRADE_FEE);
 
-        // v6: Flares require minimum publish fee
+        // v6: Flares require $0.05 minimum publish fee
         if (mode == MODE_EYES_ONLY) {
             assert!(paid_amount >= MIN_FLARE_PUBLISH_FEE + dock_upgrade_fee, E_INSUFFICIENT_FLARE_FEE);
         };

--- a/protocol/sources/siren.move
+++ b/protocol/sources/siren.move
@@ -10,6 +10,9 @@ module axiom_tide::siren {
     use sui::transfer;
     use sui::event;
     use sui::clock::{Self, Clock};
+    use sui::coin::Coin;
+    use 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC;
+    use axiom_tide::abyss::{Self, Abyss};
 
     const E_SIREN_EXPIRED: u64 = 1;
     const E_NOT_OWNER:     u64 = 2;
@@ -48,12 +51,15 @@ module axiom_tide::siren {
     }
 
     public fun sound(
+        fee_coin:        Coin<USDC>,
+        abyss:           &mut Abyss,
         owner_vessel_id: ID,
         dock_id:         ID,
         hook:            vector<u8>,
         clock:           &Clock,
         ctx:             &mut TxContext,
     ) {
+        abyss::receive_siren(abyss, fee_coin, clock, ctx);
         let owner = tx_context::sender(ctx);
         let now   = clock::timestamp_ms(clock);
         let siren = Siren {

--- a/zkproxy-worker/worker.js
+++ b/zkproxy-worker/worker.js
@@ -17,6 +17,9 @@ import { Transaction }    from '@mysten/sui/transactions'
 
 const SUI_RPC   = 'https://fullnode.mainnet.sui.io/'
 const ENOKI_URL = 'https://api.enoki.mystenlabs.com/v1/zklogin/zkp'
+const CONK_TREASURY = '0xe0117fba317d2267b8d90adca1fe79eceeec756bcf54edf04cc29ee5306ab32e'
+const CONK_USDC_TYPE = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC'
+const RETURN_FLARE_FEE_USDC = 50_000
 
 const GAS_FLOOR_MIST          = 500_000_000n  // 0.5 SUI
 const MAX_GAS_PER_IP_PER_HOUR = 50
@@ -118,6 +121,63 @@ function toB64(bytes) {
 
 function fromB64(str) {
   return Uint8Array.from(atob(str), c => c.charCodeAt(0))
+}
+
+
+// ─── Return Flare fee verification ───────────────────────────────────────────
+
+function eventAmount(event) {
+  const amount = Number(event?.parsedJson?.amount ?? 0)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function balanceChangeAmount(change) {
+  const amount = Number(change?.amount ?? 0)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function isTreasuryOwner(owner) {
+  if (!owner) return false
+  if (owner.AddressOwner) return owner.AddressOwner === CONK_TREASURY
+  if (owner.ObjectOwner) return owner.ObjectOwner === CONK_TREASURY
+  return false
+}
+
+async function verifyReturnFlareFeeTx(txDigest, kv) {
+  if (!txDigest || typeof txDigest !== 'string') return { ok: false, error: 'Return Flare fee txDigest required' }
+
+  const seenKey = 'return-flare-fee:' + txDigest
+  if (kv) {
+    const seen = await kv.get(seenKey).catch(() => null)
+    if (seen) return { ok: false, error: 'Return Flare fee txDigest already used' }
+  }
+
+  const tx = await rpc('sui_getTransactionBlock', [txDigest, {
+    showEffects: true,
+    showEvents: true,
+    showBalanceChanges: true,
+  }])
+
+  if (tx?.effects?.status?.status !== 'success') return { ok: false, error: 'Return Flare fee transaction failed' }
+
+  const feeEvent = (tx.events || []).find((event) =>
+    event.type?.endsWith('::abyss::FeeReceived') &&
+    eventAmount(event) >= RETURN_FLARE_FEE_USDC
+  )
+
+  const treasuryCredit = (tx.balanceChanges || []).find((change) =>
+    change.coinType === CONK_USDC_TYPE &&
+    isTreasuryOwner(change.owner) &&
+    balanceChangeAmount(change) >= RETURN_FLARE_FEE_USDC
+  )
+
+  if (!feeEvent && !treasuryCredit) return { ok: false, error: 'Return Flare fee transaction not found' }
+
+  if (kv) {
+    await kv.put(seenKey, '1', { expirationTtl: 60 * 60 * 24 * 30 }).catch(() => {})
+  }
+
+  return { ok: true }
 }
 
 // ─── Circuit breaker ──────────────────────────────────────────────────────────
@@ -314,8 +374,11 @@ export default {
         let data
         try { data = JSON.parse(rawBody) } catch { return errResponse('Bad JSON', 400, origin) }
 
-        const { to, hook, castId, amount, note, claimedAt } = data
+        const { to, hook, castId, amount, note, claimedAt, txDigest } = data
         if (!to || !hook || !castId) return errResponse('Missing fields', 400, origin)
+
+        const feeCheck = await verifyReturnFlareFeeTx(txDigest, env.RATE_LIMITER)
+        if (!feeCheck.ok) return errResponse(feeCheck.error, 402, origin)
 
         const amountLabel = Number(amount || 0) > 0
           ? `$${Number(amount).toFixed(3)} USDC`
@@ -356,7 +419,7 @@ export default {
           return errResponse(err, 502, origin)
         }
 
-        return jsonResponse({ ok: true }, 200, origin)
+        return jsonResponse({ ok: true, txDigest }, 200, origin)
       }
 
       // ── Flare email delivery ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- Raises Flare publish fee from 10_000 to 50_000 micro-USDC (/bin/zsh.05) in Move, app, and hosted API.\n- Adds Return Flare fee path: frontend pays 50_000 micro-USDC on-chain, worker requires and verifies txDigest before email delivery, and rejects digest reuse.\n- Aligns Siren Move primitive with Abyss fee enforcement by requiring a USDC fee coin and calling receive_siren.\n\n## Verification\n- npm run build (apps/conk) ✅\n- node --check zkproxy-worker/worker.js ✅\n- sui move build ⚠️ blocked by existing USDC dependency resolution errors in multiple pre-existing modules (relay/cast/abyss/lighthouse/harbor); not introduced by this diff.