### PR TITLE
feat: v11 — Vessel Reputation + Lighthouse Registry

### DIFF
--- a/V11-SPEC.md
+++ b/V11-SPEC.md
@@ -1,0 +1,177 @@
+# CONK Protocol · v11 Specification
+## Vessel Reputation + Lighthouse Registry
+
+**Status:** LOCKED  
+**Author:** Franklin, CTO Axiom Tide  
+**Date:** 2026-05-21  
+**Branch:** v11/reputation-registry
+
+---
+
+## Motivation
+
+v10 shipped the core settlement primitives. v11 adds the trust layer on top:
+a verifiable on-chain reputation system for Vessels and a persistent Lighthouse
+registry that agents can query directly. Both are needed before AgentSpark can
+gate anything on publisher quality.
+
+---
+
+## Bug Fixes (Ships First)
+
+### BUG-4: cast::sound() never enforces vessel::touch()
+
+`cast::sound()` takes `vessel_id: ID` and `vessel_tier: u8` as raw values with
+zero on-chain verification. `Vessel.cast_count` is silently incorrect for any
+publisher that doesn't call `touch()` separately. Any reputation ratio built
+on `cast_count` is built on sand.
+
+**Fix:** `cast::sound()` now takes `vessel: &mut Vessel` and `vessel_cap: &VesselCap`.
+It calls `vessel::touch()` internally. `vessel_id` and `vessel_tier` are derived
+from the Vessel object — not trusted from the caller.
+
+### BUG-5: lighthouse::raise() has no Cast validation
+
+`lighthouse::raise()` takes `cast_id: ID`, `vessel_id: ID`, `content_blob: vector<u8>`,
+`birth_path: u8` all as arbitrary values with no on-chain checks. Anyone can
+fabricate a fraudulent Lighthouse object. The registry built on top of this would
+be garbage from day one.
+
+**Fix:** `lighthouse::raise()` now takes `&Cast` (shared object, readable by anyone),
+`&mut Vessel`, and `&VesselCap`. It asserts `cast::is_lighthouse(cast)`, derives all
+fields from the Cast, and verifies the Vessel matches the Cast's `vessel_id`.
+It is callable only by the Cast's publisher (Vessel owner), which is correct —
+only the publisher benefits from raising their Lighthouse, and this ensures the
+`lighthouse_count` increment on the Vessel is legitimate.
+
+---
+
+## New Modules
+
+### config.move — ProtocolConfig
+
+Shared object created at deploy time. Stores the current Lighthouse threshold.
+
+**Threshold formula:**
+```
+threshold = max(MIN_THRESHOLD, drift.lh_count × SCARCITY_MULTIPLIER)
+```
+- `MIN_THRESHOLD` = 1,000 reads (achievable at current scale)
+- `SCARCITY_MULTIPLIER` = 100
+
+At 0 Lighthouses: threshold = 1,000  
+At 100 Lighthouses: threshold = 10,000  
+At 10,000 Lighthouses: threshold = 1,000,000 (original design target)
+
+**Rule:** threshold can only increase. The ratchet is enforced on-chain.
+
+**`recalibrate(config, drift, clock)`** — permissionless. Anyone can call it.
+It reads `drift::lh_count()` and updates the threshold if the formula produces
+a higher value. Anyone calling a milestone read that pushes over a threshold
+boundary can trigger recalibration atomically via PTB.
+
+**`vessel_age_gate_ms`** — reserved field, set to 0 (disabled). Future anti-gaming
+gate for reader Vessel age. Requires passing reader Vessel to `cast::read()` —
+deferred to v12 pending agent adoption analysis.
+
+### registry.move — LighthouseRegistry
+
+Shared object created at deploy time. `Table<ID, LighthouseEntry>` keyed by `cast_id`.
+
+**O(1) operations available to any contract:**
+- `registry::contains(registry, cast_id): bool` — "is this Cast a Lighthouse?"
+- `registry::lookup(registry, cast_id): &LighthouseEntry` — metadata fetch
+
+**Listing/ordering** is handled by the indexer via `LighthouseRegistered` events.
+The Table does not support iteration by design.
+
+**`LighthouseEntry` fields:**
+- cast_id, vessel_id, lighthouse_id
+- registered_at, birth_path, total_reads_at_birth
+- last_visit_at (updated by lighthouse::visit() via registry::record_visit())
+
+---
+
+## Protocol Changes
+
+### vessel.move
+
+- **Add** `lighthouse_count: u64` to Vessel struct (init: 0)
+- **Add** `vessel::record_lighthouse(vessel, cap)` — owner-gated counter increment
+- **Add** `vessel::lighthouse_count()` accessor
+
+### cast.move
+
+- **Add** `lighthouse_path: u8` to Cast struct (set in become_lighthouse())
+- **Fix** `sound()` signature: `vessel_id: ID, vessel_tier: u8` → `vessel: &mut Vessel, vessel_cap: &VesselCap`
+- **Fix** `sound()` body: calls `vessel::touch()` internally; derives vessel_id/tier from object
+- **Add** `vessel_id: address` to `CastSounded` event (enables vessel-keyed indexing without object reads)
+- **Change** `read()` signature: add `config: &ProtocolConfig`
+- **Change** `check_tide()`: uses `config::lighthouse_threshold(config)` instead of hardcoded 1M
+- **Change** `become_lighthouse()`: takes `path: u8`, sets `cast.lighthouse_path`
+- **Add** `cast::content_blob()` accessor (fields are readable on shared objects anyway)
+- **Add** `cast::lighthouse_path()` accessor
+
+### lighthouse.move
+
+- **Fix** `raise()` signature: takes `&Cast, &mut Vessel, &VesselCap, &mut LighthouseRegistry, &mut Drift`
+- **Fix** `raise()` body: asserts `is_lighthouse`, verifies vessel_id matches, derives all fields from Cast
+- **Change** `raise()` body: calls `vessel::record_lighthouse()`, `registry::register()`, `drift::index_lighthouse()`
+- **Change** `visit()` body: calls `registry::record_visit()` for last_visit_at tracking
+- **Add** `lighthouse::cast_id_address()` accessor (returns address form for events)
+
+### stream.move
+
+- **Add** `vessel_id: ID` to Stream struct
+- **Change** `create()` signature: add `vessel_id: ID`
+- **Add** `vessel_id: address` to `StreamCreated` event
+- **Add** `stream::vessel_id()` accessor
+
+---
+
+## Dependency Graph (no cycles)
+
+```
+abyss.move      ← no axiom_tide deps
+drift.move      ← no axiom_tide deps
+vessel.move     ← no axiom_tide deps
+config.move     ← drift
+registry.move   ← no axiom_tide deps
+cast.move       ← abyss, vessel, config
+lighthouse.move ← cast, vessel, registry, drift
+stream.move     ← abyss
+chest.move      ← abyss (unchanged)
+harbor.move     ← (unchanged)
+siren.move      ← abyss (unchanged)
+dock.move       ← (unchanged)
+relay.move      ← (unchanged)
+```
+
+---
+
+## SDK Impact (conk-sdk v0.4.0)
+
+All callers of changed functions need updates:
+
+| Function | Breaking Change |
+|---|---|
+| `cast.sound()` | Pass `vessel` + `vesselCap` objects instead of `vesselId + tier` |
+| `cast.read()` | Pass `protocolConfig` shared object |
+| `lighthouse.raise()` | Pass `cast`, `vessel`, `vesselCap`, `registry`, `drift` objects |
+| `stream.create()` | Pass `vesselId` |
+
+New shared objects to register in SDK config:
+- `PROTOCOL_CONFIG_ID` (from v11 deploy)
+- `LIGHTHOUSE_REGISTRY_ID` (from v11 deploy)
+
+---
+
+## What Does NOT Change
+
+- Abyss address (same shared object, reused)
+- Drift address (same shared object, reused)
+- All fee constants
+- chest.move, harbor.move, siren.move, dock.move, relay.move logic
+- The 97/3 split
+- Lighthouse permanence (100-year clock stays)
+- The kill() mechanism ($1M to remove)

--- a/protocol/Move.toml
+++ b/protocol/Move.toml
@@ -1,7 +1,8 @@
 [package]
 name = "axiom_tide"
 edition = "2024.beta"
-published-at = "0x50515260e8f766ad01461f78065b18510fef6879c3a8a776edc7da76a1db62a8"
+# v11 — pending deploy
+# published-at = "0x50515260e8f766ad01461f78065b18510fef6879c3a8a776edc7da76a1db62a8"  # v10 (inactive)
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet", override = true }

--- a/protocol/sources/cast.move
+++ b/protocol/sources/cast.move
@@ -1,10 +1,16 @@
-/// AXIOM TIDE PROTOCOL · v6.0.0
+/// AXIOM TIDE PROTOCOL · v11.0.0
 /// PRIMITIVE 3 OF 7 · CAST
 /// The communication primitive. Everything is a cast.
 /// Open · Sealed · Eyes Only · Ghost.
 /// v5: Dock mechanics — single-claim by default, open-Dock upgrade at $0.01/slot.
 /// v5: Author payment routing fixed (97% to author, not recipient).
 /// v5: Tide & Lighthouse mechanics preserved on-chain, hidden in CONK UI.
+/// v6: Flare minimum publish fee ($0.05).
+/// v11: BUG-4 fixed — sound() requires &mut Vessel + &VesselCap, calls touch() internally.
+///      vessel_id and vessel_tier derived from Vessel object — not trusted from caller.
+/// v11: lighthouse_path added to Cast struct; set in become_lighthouse().
+/// v11: vessel_id added to CastSounded event for indexer attribution.
+/// v11: read() accepts &ProtocolConfig for dynamic Lighthouse threshold.
 /// Copyright © 2026 Axiom Tide LLC · axiomtide.com
 module axiom_tide::cast {
     use sui::object::{Self, UID, ID};
@@ -15,6 +21,8 @@ module axiom_tide::cast {
     use sui::coin::{Self, Coin};
     use 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC;
     use axiom_tide::abyss::{Self, Abyss};
+    use axiom_tide::vessel::{Self, Vessel, VesselCap};
+    use axiom_tide::config::{Self, ProtocolConfig};
 
     const E_CAST_EXPIRED:             u64 = 1;
     const E_WRONG_RECIPIENT:          u64 = 2;
@@ -23,14 +31,13 @@ module axiom_tide::cast {
     const E_DOCK_FULL:                u64 = 5;
     const E_INVALID_MAX_CLAIMS:       u64 = 6;
     const E_INSUFFICIENT_UPGRADE_FEE: u64 = 7;
-    const E_INSUFFICIENT_FLARE_FEE:   u64 = 8;  // v6: publish fee below Flare minimum
+    const E_INSUFFICIENT_FLARE_FEE:   u64 = 8;
 
-    const MIN_PAID_PRICE:    u64 = 1_000;
-
-    const DOCK_SLOT_PRICE:        u64 = 10_000;
-    const MIN_FLARE_PUBLISH_FEE:  u64 = 50_000;  // v6: $0.05 minimum to send a Flare (EYES_ONLY)
-    const MIN_MAX_CLAIMS:    u64 = 1;
-    const MAX_MAX_CLAIMS:    u64 = 10_000;
+    const MIN_PAID_PRICE:   u64 = 1_000;
+    const DOCK_SLOT_PRICE:  u64 = 10_000;
+    const MIN_FLARE_PUBLISH_FEE: u64 = 50_000;
+    const MIN_MAX_CLAIMS:   u64 = 1;
+    const MAX_MAX_CLAIMS:   u64 = 10_000;
 
     const MODE_OPEN:      u8 = 0;
     const MODE_SEALED:    u8 = 1;
@@ -45,6 +52,10 @@ module axiom_tide::cast {
     const DUR_72H: u8 = 3;
     const DUR_7D:  u8 = 4;
     const MS_24H:  u64 = 24 * 60 * 60 * 1000;
+
+    /// v11: birth paths for Lighthouse (mirrors lighthouse.move constants)
+    const LH_PATH_MILLION: u8 = 1;
+    const LH_PATH_TIDES:   u8 = 2;
 
     public struct Cast has key, store {
         id:                    UID,
@@ -70,10 +81,18 @@ module axiom_tide::cast {
         claims_used:           u64,
         dock_upgrade_fee_paid: u64,
         dock_description:      vector<u8>,
+        /// v11: which path earned Lighthouse status.
+        /// LH_PATH_MILLION (1) = 1M reads in 24h.
+        /// LH_PATH_TIDES   (2) = 3 × tide_threshold reads.
+        /// 0 = not a Lighthouse.
+        lighthouse_path:       u8,
     }
+
+    // ─── Events ───────────────────────────────────────────────────────────────
 
     public struct CastSounded has copy, drop {
         cast_id:    address,
+        vessel_id:  address,   // v11: added for indexer attribution without object reads
         hook:       vector<u8>,
         mode:       u8,
         duration:   u8,
@@ -101,9 +120,10 @@ module axiom_tide::cast {
     }
 
     public struct LighthouseBorn has copy, drop {
-        cast_id:    address,
-        read_count: u64,
-        born_at:    u64,
+        cast_id:     address,
+        birth_path:  u8,        // v11: included in event
+        read_count:  u64,
+        born_at:     u64,
     }
 
     public struct DockOpened has copy, drop {
@@ -121,11 +141,18 @@ module axiom_tide::cast {
         claimed_at:  u64,
     }
 
+    // ─── sound() — BUG-4 FIX ──────────────────────────────────────────────────
+    //
+    // v11 breaking change: `vessel_id: ID` and `vessel_tier: u8` removed.
+    // Caller must pass the actual Vessel and VesselCap objects.
+    // vessel::touch() is called internally — cast_count is now protocol-enforced.
+    // vessel_id and vessel_tier are derived from the Vessel object, not trusted input.
+
     public fun sound(
         fee_coin:         Coin<USDC>,
         abyss:            &mut Abyss,
-        vessel_id:        ID,
-        vessel_tier:      u8,
+        vessel:           &mut Vessel,      // v11: was vessel_id: ID
+        vessel_cap:       &VesselCap,       // v11: new — for ownership + touch()
         hook:             vector<u8>,
         content_blob:     vector<u8>,
         media_blob:       Option<vector<u8>>,
@@ -144,20 +171,27 @@ module axiom_tide::cast {
         let paid_amount = coin::value(&fee_coin);
         assert!(paid_amount >= dock_upgrade_fee, E_INSUFFICIENT_UPGRADE_FEE);
 
-        // v6: Flares require $0.05 minimum publish fee
         if (mode == MODE_EYES_ONLY) {
             assert!(paid_amount >= MIN_FLARE_PUBLISH_FEE + dock_upgrade_fee, E_INSUFFICIENT_FLARE_FEE);
         };
 
+        // v11: enforce cast_count via protocol — not caller-trust.
+        // touch() asserts VesselCap ownership, Vessel liveness, and increments cast_count.
+        // Returns burn_after_cast — caller (SDK) sinks Vessel after PTB if true.
+        let _burn_after_cast = vessel::touch(vessel, vessel_cap, clock, ctx);
+
+        // Derive vessel_id and tier from object — not trusted from caller.
+        let vessel_id   = object::id(vessel);
+        let vessel_tier = vessel::tier(vessel);
+        let author_addr = vessel::owner(vessel);   // author = vessel owner, not tx sender
+
         let now     = clock::timestamp_ms(clock);
-        let life_ms = if (duration == DUR_24H) MS_24H
-                      else if (duration == DUR_48H) MS_24H * 2
-                      else if (duration == DUR_72H) MS_24H * 3
-                      else MS_24H * 7;
+        let life_ms = if (duration == DUR_24H)      { MS_24H }
+                      else if (duration == DUR_48H)  { MS_24H * 2 }
+                      else if (duration == DUR_72H)  { MS_24H * 3 }
+                      else                           { MS_24H * 7 };
 
         abyss::receive_cast(abyss, fee_coin, clock, ctx);
-
-        let author_addr = tx_context::sender(ctx);
 
         let cast = Cast {
             id:                    object::new(ctx),
@@ -183,11 +217,13 @@ module axiom_tide::cast {
             claims_used:           0,
             dock_upgrade_fee_paid: dock_upgrade_fee,
             dock_description,
+            lighthouse_path:       0,   // v11
         };
         let cast_id = object::id_to_address(&object::id(&cast));
 
         event::emit(CastSounded {
             cast_id,
+            vessel_id: object::id_to_address(&vessel_id),   // v11
             hook: cast.hook,
             mode,
             duration,
@@ -207,10 +243,13 @@ module axiom_tide::cast {
         transfer::share_object(cast);
     }
 
+    // ─── read() — v11: adds &ProtocolConfig for dynamic threshold ─────────────
+
     public fun read(
         cast:     &mut Cast,
         fee_coin: Coin<USDC>,
         abyss:    &mut Abyss,
+        config:   &ProtocolConfig,   // v11: dynamic Lighthouse threshold
         reader:   address,
         clock:    &Clock,
         ctx:      &mut TxContext,
@@ -266,19 +305,28 @@ module axiom_tide::cast {
             return
         };
 
-        if (cast.mode == MODE_OPEN) { check_tide(cast, clock); };
+        // Tide/Lighthouse check: only OPEN Casts qualify.
+        if (cast.mode == MODE_OPEN) { check_tide(cast, config, clock); };
     }
 
-    fun check_tide(cast: &mut Cast, clock: &Clock) {
+    // ─── Internal ─────────────────────────────────────────────────────────────
+
+    fun check_tide(cast: &mut Cast, config: &ProtocolConfig, clock: &Clock) {
         if (cast.is_lighthouse) return;
-        let now    = clock::timestamp_ms(clock);
-        let age_ms = now - cast.created_at;
-        if (age_ms <= MS_24H && cast.read_count >= 1_000_000) {
-            become_lighthouse(cast, now);
+
+        let now            = clock::timestamp_ms(clock);
+        let age_ms         = now - cast.created_at;
+        let threshold      = config::lighthouse_threshold(config);
+        let tide_threshold = config::tide_threshold(config);  // threshold / 2
+
+        // Direct path: threshold reads within 24h
+        if (age_ms <= MS_24H && cast.read_count >= threshold) {
+            become_lighthouse(cast, LH_PATH_MILLION, now);
             return
         };
+
         if (cast.current_tide == 1) {
-            if (cast.read_count >= 500_000 && age_ms <= MS_24H) {
+            if (cast.read_count >= tide_threshold && age_ms <= MS_24H) {
                 cast.tide_1_count = cast.read_count;
                 cast.current_tide = 2;
                 cast.expires_at   = cast.created_at + (MS_24H * 2);
@@ -291,7 +339,7 @@ module axiom_tide::cast {
             }
         } else if (cast.current_tide == 2) {
             let tide_2 = cast.read_count - cast.tide_1_count;
-            if (tide_2 >= 500_000) {
+            if (tide_2 >= tide_threshold) {
                 cast.tide_2_count = tide_2;
                 cast.current_tide = 3;
                 cast.expires_at   = cast.created_at + (MS_24H * 3);
@@ -304,44 +352,52 @@ module axiom_tide::cast {
             }
         } else if (cast.current_tide == 3) {
             let tide_3 = cast.read_count - cast.tide_1_count - cast.tide_2_count;
-            if (tide_3 >= 500_000) {
+            if (tide_3 >= tide_threshold) {
                 cast.tide_3_count = tide_3;
-                become_lighthouse(cast, now);
+                become_lighthouse(cast, LH_PATH_TIDES, now);
             }
         }
     }
 
-    fun become_lighthouse(cast: &mut Cast, now: u64) {
-        cast.is_lighthouse = true;
-        cast.expires_at    = now + (100 * 365 * 24 * 60 * 60 * 1000);
+    fun become_lighthouse(cast: &mut Cast, path: u8, now: u64) {
+        cast.is_lighthouse   = true;
+        cast.lighthouse_path = path;   // v11: record the path
+        cast.expires_at      = now + (100 * 365 * 24 * 60 * 60 * 1000);
         event::emit(LighthouseBorn {
             cast_id:    object::id_to_address(&object::id(cast)),
+            birth_path: path,      // v11: included in event
             read_count: cast.read_count,
             born_at:    now,
         });
     }
 
-    public fun hook(c: &Cast):          vector<u8> { c.hook }
-    public fun mode(c: &Cast):          u8         { c.mode }
-    public fun state(c: &Cast):         u8         { c.state }
-    public fun read_count(c: &Cast):    u64        { c.read_count }
-    public fun is_lighthouse(c: &Cast): bool       { c.is_lighthouse }
-    public fun current_tide(c: &Cast):  u8         { c.current_tide }
-    public fun expires_at(c: &Cast):    u64        { c.expires_at }
-    public fun vessel_id(c: &Cast):     ID         { c.vessel_id }
-    public fun mode_open():      u8 { MODE_OPEN }
-    public fun mode_sealed():    u8 { MODE_SEALED }
-    public fun mode_eyes_only(): u8 { MODE_EYES_ONLY }
-    public fun mode_ghost():     u8 { MODE_GHOST }
-
-    public fun author(c: &Cast):                address    { c.author }
-    public fun max_claims(c: &Cast):            u64        { c.max_claims }
-    public fun claims_used(c: &Cast):           u64        { c.claims_used }
-    public fun claims_remaining(c: &Cast):      u64 {
+    // ─── View helpers ─────────────────────────────────────────────────────────
+    public fun hook(c: &Cast):             vector<u8> { c.hook }
+    public fun mode(c: &Cast):             u8         { c.mode }
+    public fun state(c: &Cast):            u8         { c.state }
+    public fun read_count(c: &Cast):       u64        { c.read_count }
+    public fun is_lighthouse(c: &Cast):    bool       { c.is_lighthouse }
+    public fun current_tide(c: &Cast):     u8         { c.current_tide }
+    public fun expires_at(c: &Cast):       u64        { c.expires_at }
+    public fun vessel_id(c: &Cast):        ID         { c.vessel_id }
+    public fun vessel_tier(c: &Cast):      u8         { c.vessel_tier }
+    public fun author(c: &Cast):           address    { c.author }
+    public fun max_claims(c: &Cast):       u64        { c.max_claims }
+    public fun claims_used(c: &Cast):      u64        { c.claims_used }
+    public fun lighthouse_path(c: &Cast):  u8         { c.lighthouse_path }   // v11
+    public fun content_blob(c: &Cast):     vector<u8> { c.content_blob }      // v11
+    public fun claims_remaining(c: &Cast): u64 {
         if (c.claims_used >= c.max_claims) 0
         else c.max_claims - c.claims_used
     }
     public fun is_dock_full(c: &Cast):          bool       { c.claims_used >= c.max_claims }
     public fun dock_description(c: &Cast):      vector<u8> { c.dock_description }
     public fun dock_upgrade_fee_paid(c: &Cast): u64        { c.dock_upgrade_fee_paid }
+
+    public fun mode_open():      u8 { MODE_OPEN }
+    public fun mode_sealed():    u8 { MODE_SEALED }
+    public fun mode_eyes_only(): u8 { MODE_EYES_ONLY }
+    public fun mode_ghost():     u8 { MODE_GHOST }
+    public fun lh_path_million(): u8 { LH_PATH_MILLION }
+    public fun lh_path_tides():   u8 { LH_PATH_TIDES }
 }

--- a/protocol/sources/config.move
+++ b/protocol/sources/config.move
@@ -1,0 +1,113 @@
+/// AXIOM TIDE PROTOCOL · v11.0.0
+/// PROTOCOL CONFIG · Dynamic Lighthouse Threshold
+/// Threshold = max(FLOOR, lh_count × SCARCITY_MULTIPLIER).
+/// Only increases. Scarcity is permanent.
+/// Permissionless recalibration — anyone may call recalibrate().
+/// Copyright © 2026 Axiom Tide LLC · axiomtide.com
+module axiom_tide::config {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use sui::event;
+    use sui::clock::{Self, Clock};
+    use axiom_tide::drift::{Self, Drift};
+
+    // ─── Constants ────────────────────────────────────────────────────────────
+    const MIN_THRESHOLD:       u64 = 1_000;   // $0.001 × 1000 = $1 attack cost floor
+    const SCARCITY_MULTIPLIER: u64 = 100;     // threshold = lh_count × 100
+    const AGE_GATE_DISABLED:   u64 = 0;       // vessel_age_gate_ms: 0 = disabled
+
+    // ─── Errors ───────────────────────────────────────────────────────────────
+    const E_THRESHOLD_BELOW_FLOOR: u64 = 1;   // reserved for future admin floor-change gate
+
+    // ─── Structs ──────────────────────────────────────────────────────────────
+
+    public struct ProtocolConfig has key {
+        id:                   UID,
+        /// Current Lighthouse read threshold (24h window).
+        /// Computed as max(min_threshold, lh_count × scarcity_multiplier).
+        /// Monotonically increasing — never decreases.
+        lighthouse_threshold: u64,
+        /// Hard floor — threshold never drops below this value.
+        min_threshold:        u64,
+        /// Multiplier applied to lh_count for threshold scaling.
+        scarcity_multiplier:  u64,
+        /// Reserved: minimum Vessel age in ms for a read to count toward
+        /// Lighthouse threshold. 0 = disabled. Future anti-gaming gate.
+        vessel_age_gate_ms:   u64,
+        /// Timestamp of last recalibration.
+        last_recalibrated:    u64,
+    }
+
+    // ─── Events ───────────────────────────────────────────────────────────────
+
+    public struct ThresholdRatcheted has copy, drop {
+        old_threshold: u64,
+        new_threshold: u64,
+        lh_count:      u64,
+        ratcheted_at:  u64,
+    }
+
+    // ─── Init ─────────────────────────────────────────────────────────────────
+
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(ProtocolConfig {
+            id:                   object::new(ctx),
+            lighthouse_threshold: MIN_THRESHOLD,
+            min_threshold:        MIN_THRESHOLD,
+            scarcity_multiplier:  SCARCITY_MULTIPLIER,
+            vessel_age_gate_ms:   AGE_GATE_DISABLED,
+            last_recalibrated:    0,
+        });
+    }
+
+    // ─── Public entry points ──────────────────────────────────────────────────
+
+    /// Permissionless recalibration.
+    ///
+    /// Reads drift.lh_count and computes:
+    ///   new_threshold = max(min_threshold, lh_count × scarcity_multiplier)
+    ///
+    /// Updates threshold only if new_threshold > current (ratchet: up only).
+    /// Can be called by anyone — typically in the same PTB as the read that
+    /// crosses a Lighthouse milestone, so the threshold is current atomically.
+    public fun recalibrate(
+        config: &mut ProtocolConfig,
+        drift:  &Drift,
+        clock:  &Clock,
+        _ctx:   &TxContext,
+    ) {
+        let lh_count      = drift::lh_count(drift);
+        let scaled        = lh_count * config.scarcity_multiplier;
+        let new_threshold = if (scaled > config.min_threshold) { scaled }
+                            else { config.min_threshold };
+
+        if (new_threshold > config.lighthouse_threshold) {
+            let old = config.lighthouse_threshold;
+            config.lighthouse_threshold = new_threshold;
+            config.last_recalibrated    = clock::timestamp_ms(clock);
+            event::emit(ThresholdRatcheted {
+                old_threshold: old,
+                new_threshold,
+                lh_count,
+                ratcheted_at: config.last_recalibrated,
+            });
+        }
+    }
+
+    // ─── View helpers ─────────────────────────────────────────────────────────
+    public fun lighthouse_threshold(c: &ProtocolConfig): u64 { c.lighthouse_threshold }
+    public fun min_threshold(c: &ProtocolConfig):        u64 { c.min_threshold }
+    public fun scarcity_multiplier(c: &ProtocolConfig):  u64 { c.scarcity_multiplier }
+    public fun vessel_age_gate_ms(c: &ProtocolConfig):   u64 { c.vessel_age_gate_ms }
+    public fun last_recalibrated(c: &ProtocolConfig):    u64 { c.last_recalibrated }
+
+    // ─── Internal (used by cast::check_tide) ──────────────────────────────────
+    /// Tide thresholds scale proportionally:
+    ///   each tide = lighthouse_threshold / 2
+    /// At threshold=1000: each tide = 500
+    /// At threshold=10000: each tide = 5000
+    public fun tide_threshold(c: &ProtocolConfig): u64 {
+        c.lighthouse_threshold / 2
+    }
+}

--- a/protocol/sources/lighthouse.move
+++ b/protocol/sources/lighthouse.move
@@ -1,21 +1,31 @@
-/// AXIOM TIDE PROTOCOL · v1.0.0
+/// AXIOM TIDE PROTOCOL · v11.0.0
 /// PRIMITIVE 7 OF 7 · LIGHTHOUSE
 /// The permanent record. Earned by the tide. Never purchased.
-/// 1M reads in 24hrs or 500k x 3 tides.
 /// 100yr clock. $1M to remove. No human override. Ever.
 /// GENESIS LIGHTHOUSE · placed by founder · free · permanent · forever.
+/// v11: BUG-5 fixed — raise() now takes &Cast and validates is_lighthouse.
+///      vessel_id, content_blob, and birth_path derived from Cast — not caller-trusted.
+///      raise() is now publisher-only (requires Vessel + VesselCap).
+///      Atomically registers into LighthouseRegistry and indexes into Drift.
+///      visit() updates registry last_visit_at.
 /// Copyright © 2026 Axiom Tide LLC · axiomtide.com
 module axiom_tide::lighthouse {
     use sui::object::{Self, UID, ID};
-    use sui::tx_context::{Self, TxContext};
+    use sui::tx_context::TxContext;
     use sui::transfer;
     use sui::event;
     use sui::clock::{Self, Clock};
     use sui::coin::{Self, Coin};
     use 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC;
+    use axiom_tide::cast::{Self, Cast};
+    use axiom_tide::vessel::{Self, Vessel, VesselCap};
+    use axiom_tide::registry::{Self, LighthouseRegistry};
+    use axiom_tide::drift::{Self, Drift};
 
     const E_INSUFFICIENT_KILL: u64 = 1;
-    const E_GENESIS_IMMORTAL:  u64 = 2;
+    const E_GENESIS_IMMORTAL:  u64 = 2;   // reserved for future GenesisLighthouse kill-gate
+    const E_CAST_NOT_LIGHTHOUSE: u64 = 3;  // v11: Cast has not earned Lighthouse status
+    const E_VESSEL_MISMATCH:    u64 = 4;   // v11: Cast's vessel_id ≠ provided Vessel
 
     const LH_LIFESPAN_MS: u64 = 100 * 365 * 24 * 60 * 60 * 1000;
     const KILL_COST:       u64 = 1_000_000_000_000;
@@ -47,6 +57,7 @@ module axiom_tide::lighthouse {
     public struct LighthouseStands has copy, drop {
         lighthouse_id: address,
         cast_id:       address,
+        vessel_id:     address,
         birth_path:    u8,
         total_reads:   u64,
         stands_at:     u64,
@@ -78,17 +89,46 @@ module axiom_tide::lighthouse {
         visited_at:    u64,
     }
 
+    // ─── raise() — BUG-5 FIX ──────────────────────────────────────────────────
+    //
+    // v11 breaking change: no longer takes cast_id/vessel_id/content_blob/birth_path
+    // as raw values. Requires:
+    //   &Cast      — validates is_lighthouse, derives all fields
+    //   &mut Vessel + &VesselCap — verifies publisher identity, increments lighthouse_count
+    //   &mut LighthouseRegistry — atomically registers into the on-chain index
+    //   &mut Drift — atomically calls index_lighthouse for feed consistency
+    //
+    // Publisher-only: only the Cast's Vessel owner can call raise().
+    // Permissionless to VERIFY (the Cast is readable by anyone), but gated on
+    // Vessel ownership to ensure lighthouse_count is credibly incremented.
+
     public fun raise(
-        cast_id:      ID,
-        vessel_id:    ID,
-        content_blob: vector<u8>,
-        birth_path:   u8,
-        total_reads:  u64,
-        clock:        &Clock,
-        ctx:          &mut TxContext,
+        cast:       &Cast,
+        vessel:     &mut Vessel,
+        vessel_cap: &VesselCap,
+        registry:   &mut LighthouseRegistry,
+        drift:      &mut Drift,
+        clock:      &Clock,
+        ctx:        &mut TxContext,
     ) {
-        let now = clock::timestamp_ms(clock);
-        let lh  = Lighthouse {
+        // BUG-5: verify Cast earned Lighthouse status on-chain
+        assert!(cast::is_lighthouse(cast), E_CAST_NOT_LIGHTHOUSE);
+
+        // Verify the provided Vessel is the one that published this Cast
+        assert!(cast::vessel_id(cast) == object::id(vessel), E_VESSEL_MISMATCH);
+
+        let cast_id      = object::id(cast);
+        let vessel_id    = object::id(vessel);
+        let content_blob = cast::content_blob(cast);
+        let birth_path   = cast::lighthouse_path(cast);
+        let total_reads  = cast::read_count(cast);
+        let now          = clock::timestamp_ms(clock);
+
+        // Increment lighthouse_count on the Vessel — protocol-enforced.
+        // vessel_id match was already asserted above.
+        vessel::record_lighthouse(vessel, vessel_cap, clock);
+
+        let lh = Lighthouse {
             id:           object::new(ctx),
             cast_id,
             vessel_id,
@@ -98,32 +138,65 @@ module axiom_tide::lighthouse {
             visit_count:  total_reads,
             birth_path,
         };
-        let lh_addr   = object::id_to_address(&object::id(&lh));
+
+        let lh_id     = object::id(&lh);
+        let lh_addr   = object::id_to_address(&lh_id);
         let cast_addr = object::id_to_address(&cast_id);
+
         event::emit(LighthouseStands {
             lighthouse_id: lh_addr,
             cast_id:       cast_addr,
+            vessel_id:     object::id_to_address(&vessel_id),
             birth_path,
             total_reads,
             stands_at:     now,
         });
+
+        // Atomically register into the on-chain registry
+        registry::register(
+            registry,
+            cast_id,
+            vessel_id,
+            lh_id,
+            birth_path,
+            total_reads,
+            now,
+        );
+
+        // Atomically update Drift feed index
+        drift::index_lighthouse(drift, cast_addr, lh_addr, birth_path, clock, ctx);
+
         transfer::share_object(lh);
     }
 
+    /// Visit a Lighthouse. Updates last_visit (rolling 100yr window) and
+    /// records the visit in the registry for recency tracking.
     public fun visit(
-        lh:    &mut Lighthouse,
-        clock: &Clock,
-        _ctx:  &TxContext,
+        lh:       &mut Lighthouse,
+        registry: &mut LighthouseRegistry,
+        clock:    &Clock,
+        _ctx:     &TxContext,
     ) {
         let now        = clock::timestamp_ms(clock);
         lh.visit_count = lh.visit_count + 1;
         lh.last_visit  = now;
+
+        let lh_addr = object::id_to_address(&object::id(lh));
         event::emit(LighthouseVisited {
-            lighthouse_id: object::id_to_address(&object::id(lh)),
+            lighthouse_id: lh_addr,
             visit_count:   lh.visit_count,
             visited_at:    now,
             expires_at:    now + LH_LIFESPAN_MS,
         });
+
+        // Update registry last_visit_at for recency filtering
+        registry::record_visit(
+            registry,
+            lh.cast_id,
+            object::id(lh),
+            lh.visit_count,
+            now,
+        );
     }
 
     public fun kill(
@@ -156,7 +229,7 @@ module axiom_tide::lighthouse {
         clock:        &Clock,
         ctx:          &mut TxContext,
     ) {
-        let placer  = tx_context::sender(ctx);
+        let placer  = sui::tx_context::sender(ctx);
         let now     = clock::timestamp_ms(clock);
         let genesis = GenesisLighthouse {
             id:           object::new(ctx),
@@ -188,15 +261,18 @@ module axiom_tide::lighthouse {
         });
     }
 
-    public fun visit_count(lh: &Lighthouse):          u64        { lh.visit_count }
-    public fun birth_path(lh: &Lighthouse):           u8         { lh.birth_path }
-    public fun last_visit(lh: &Lighthouse):           u64        { lh.last_visit }
-    public fun expires_at(lh: &Lighthouse):           u64        { lh.last_visit + LH_LIFESPAN_MS }
+    // ─── View helpers ─────────────────────────────────────────────────────────
+    public fun cast_id(lh: &Lighthouse):      ID         { lh.cast_id }
+    public fun vessel_id(lh: &Lighthouse):    ID         { lh.vessel_id }
+    public fun visit_count(lh: &Lighthouse):  u64        { lh.visit_count }
+    public fun birth_path(lh: &Lighthouse):   u8         { lh.birth_path }
+    public fun last_visit(lh: &Lighthouse):   u64        { lh.last_visit }
+    public fun expires_at(lh: &Lighthouse):   u64        { lh.last_visit + LH_LIFESPAN_MS }
     public fun genesis_visits(g: &GenesisLighthouse): u64        { g.visit_count }
     public fun genesis_message(g: &GenesisLighthouse): vector<u8> { g.message }
-    public fun kill_cost():      u64 { KILL_COST }
-    public fun path_million():   u8  { PATH_MILLION }
-    public fun path_tides():     u8  { PATH_TIDES }
-    public fun path_genesis():   u8  { PATH_GENESIS }
+    public fun kill_cost():    u64 { KILL_COST }
+    public fun path_million(): u8  { PATH_MILLION }
+    public fun path_tides():   u8  { PATH_TIDES }
+    public fun path_genesis(): u8  { PATH_GENESIS }
     public fun lh_lifespan_ms(): u64 { LH_LIFESPAN_MS }
 }

--- a/protocol/sources/registry.move
+++ b/protocol/sources/registry.move
@@ -1,0 +1,161 @@
+/// AXIOM TIDE PROTOCOL · v11.0.0
+/// LIGHTHOUSE REGISTRY
+/// Persistent on-chain index of all Lighthouse-status Casts.
+/// Append-only. O(1) lookup and existence check — composable from any contract.
+/// Listing and ordering handled by indexer via LighthouseRegistered events.
+/// Table has no iteration by design: unbounded loops are gas-unsafe on Sui.
+/// Copyright © 2026 Axiom Tide LLC · axiomtide.com
+module axiom_tide::registry {
+    use sui::object::{Self, UID, ID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use sui::event;
+    use sui::table::{Self, Table};
+
+    // ─── Errors ───────────────────────────────────────────────────────────────
+    const E_ALREADY_REGISTERED: u64 = 1;
+    const E_NOT_FOUND:          u64 = 2;
+
+    // ─── Structs ──────────────────────────────────────────────────────────────
+
+    public struct LighthouseRegistry has key {
+        id:            UID,
+        /// cast_id → LighthouseEntry. Keyed by cast_id for O(1) composable lookup.
+        entries:       Table<ID, LighthouseEntry>,
+        /// Running count of registered Lighthouses.
+        count:         u64,
+        /// Timestamp of the most recent registration.
+        last_added_at: u64,
+    }
+
+    /// Immutable entry stored per Lighthouse.
+    /// last_visit_at is the one mutable field — updated by lighthouse::visit().
+    public struct LighthouseEntry has store, copy, drop {
+        cast_id:              ID,
+        vessel_id:            ID,
+        lighthouse_id:        ID,
+        registered_at:        u64,
+        birth_path:           u8,
+        total_reads_at_birth: u64,
+        /// Last time lighthouse::visit() was called. Updated in place.
+        /// Indexers filter by recency using this field.
+        last_visit_at:        u64,
+    }
+
+    // ─── Events ───────────────────────────────────────────────────────────────
+
+    public struct LighthouseRegistered has copy, drop {
+        cast_id:       ID,
+        vessel_id:     ID,
+        lighthouse_id: ID,
+        birth_path:    u8,
+        reads_at_birth: u64,
+        registry_size: u64,
+        registered_at: u64,
+    }
+
+    public struct RegistryVisitRecorded has copy, drop {
+        cast_id:       ID,
+        lighthouse_id: ID,
+        visit_count:   u64,
+        last_visit_at: u64,
+    }
+
+    // ─── Init ─────────────────────────────────────────────────────────────────
+
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(LighthouseRegistry {
+            id:            object::new(ctx),
+            entries:       table::new(ctx),
+            count:         0,
+            last_added_at: 0,
+        });
+    }
+
+    // ─── Internal writers (called only by lighthouse.move) ────────────────────
+
+    /// Register a new Lighthouse. Called atomically inside lighthouse::raise().
+    /// Aborts if already registered — raise() is idempotent on the Cast level.
+    public fun register(
+        registry:      &mut LighthouseRegistry,
+        cast_id:       ID,
+        vessel_id:     ID,
+        lighthouse_id: ID,
+        birth_path:    u8,
+        total_reads:   u64,
+        now:           u64,
+    ) {
+        assert!(!table::contains(&registry.entries, cast_id), E_ALREADY_REGISTERED);
+
+        let entry = LighthouseEntry {
+            cast_id,
+            vessel_id,
+            lighthouse_id,
+            registered_at:        now,
+            birth_path,
+            total_reads_at_birth: total_reads,
+            last_visit_at:        now,
+        };
+
+        table::add(&mut registry.entries, cast_id, entry);
+        registry.count         = registry.count + 1;
+        registry.last_added_at = now;
+
+        event::emit(LighthouseRegistered {
+            cast_id,
+            vessel_id,
+            lighthouse_id,
+            birth_path,
+            reads_at_birth: total_reads,
+            registry_size:  registry.count,
+            registered_at:  now,
+        });
+    }
+
+    /// Update last_visit_at when lighthouse::visit() is called.
+    /// No-op if the cast_id isn't in the registry (defensive; shouldn't happen).
+    public fun record_visit(
+        registry:      &mut LighthouseRegistry,
+        cast_id:       ID,
+        lighthouse_id: ID,
+        visit_count:   u64,
+        now:           u64,
+    ) {
+        if (!table::contains(&registry.entries, cast_id)) { return };
+        let entry          = table::borrow_mut(&mut registry.entries, cast_id);
+        entry.last_visit_at = now;
+        event::emit(RegistryVisitRecorded {
+            cast_id,
+            lighthouse_id,
+            visit_count,
+            last_visit_at: now,
+        });
+    }
+
+    // ─── Public read interface ─────────────────────────────────────────────────
+
+    /// O(1) existence check — composable from any contract.
+    /// Primary use: gate logic that requires Lighthouse status.
+    public fun contains(registry: &LighthouseRegistry, cast_id: ID): bool {
+        table::contains(&registry.entries, cast_id)
+    }
+
+    /// O(1) entry lookup. Aborts with E_NOT_FOUND if not registered.
+    public fun lookup(registry: &LighthouseRegistry, cast_id: ID): &LighthouseEntry {
+        assert!(table::contains(&registry.entries, cast_id), E_NOT_FOUND);
+        table::borrow(&registry.entries, cast_id)
+    }
+
+    // ─── Registry-level view helpers ──────────────────────────────────────────
+    public fun count(r: &LighthouseRegistry):         u64 { r.count }
+    public fun last_added_at(r: &LighthouseRegistry): u64 { r.last_added_at }
+
+    // ─── Entry view helpers ───────────────────────────────────────────────────
+    public fun entry_cast_id(e: &LighthouseEntry):      ID  { e.cast_id }
+    public fun entry_vessel_id(e: &LighthouseEntry):    ID  { e.vessel_id }
+    public fun entry_lighthouse_id(e: &LighthouseEntry): ID { e.lighthouse_id }
+    public fun entry_birth_path(e: &LighthouseEntry):   u8  { e.birth_path }
+    public fun entry_reads(e: &LighthouseEntry):        u64 { e.total_reads_at_birth }
+    public fun entry_registered_at(e: &LighthouseEntry): u64 { e.registered_at }
+    public fun entry_last_visit(e: &LighthouseEntry):   u64 { e.last_visit_at }
+}

--- a/protocol/sources/stream.move
+++ b/protocol/sources/stream.move
@@ -1,10 +1,12 @@
-/// AXIOM TIDE PROTOCOL · v1.0.0
+/// AXIOM TIDE PROTOCOL · v11.0.0
 /// PRIMITIVE 9 OF 9 · STREAM
 /// Time-gated paid access sessions for live content on Sui.
 /// Creators open a Stream. Viewers join and receive a StreamSession.
 /// Three payment models: Per-View · Per-Minute · Subscription.
 /// Revenue split: 97% to creator / 3% to Abyss on every join.
 /// End closes the stream and optionally links a VOD Chest.
+/// v11: vessel_id added to Stream struct and StreamCreated event.
+///      Enables cross-primitive reputation aggregation in the indexer.
 /// Copyright © 2026 Axiom Tide LLC · axiomtide.com
 module axiom_tide::stream {
     use sui::object::{Self, UID, ID};
@@ -17,39 +19,31 @@ module axiom_tide::stream {
     use 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC;
     use axiom_tide::abyss::{Self, Abyss};
 
-    // ─── Error codes ──────────────────────────────────────────────────────────
     const E_STREAM_CLOSED:        u64 = 1;
     const E_NOT_CREATOR:          u64 = 2;
     const E_PRICE_TOO_LOW:        u64 = 3;
     const E_INSUFFICIENT_FEE:     u64 = 4;
     const E_INVALID_PAYMENT_TYPE: u64 = 5;
 
-    // ─── Payment types ────────────────────────────────────────────────────────
-    const PAYMENT_PER_VIEW:    u8 = 0;   // one-time access fee
-    const PAYMENT_PER_MINUTE:  u8 = 1;   // fee scales with session duration
-    const PAYMENT_SUBSCRIPTION: u8 = 2;  // recurring subscription model
+    const PAYMENT_PER_VIEW:     u8 = 0;
+    const PAYMENT_PER_MINUTE:   u8 = 1;
+    const PAYMENT_SUBSCRIPTION: u8 = 2;
 
-    // ─── Protocol fees (USDC 6-decimal microunits: 1_000_000 = $1.00) ─────────
-    const FEE_STREAM_CREATE: u64 = 50_000;  // $0.05 to open a stream
-    const MIN_SESSION_PRICE: u64 = 10_000;  // $0.01 floor per viewer session
-    const PROTOCOL_BPS:      u64 = 300;     // 3% of session fee (30/1000)
+    const FEE_STREAM_CREATE: u64 = 50_000;
+    const MIN_SESSION_PRICE: u64 = 10_000;
+    const PROTOCOL_BPS:      u64 = 300;
 
-    // ─── State ────────────────────────────────────────────────────────────────
     const STATE_LIVE:   u8 = 0;
     const STATE_CLOSED: u8 = 1;
 
-    // ─── Structs ──────────────────────────────────────────────────────────────
-
-    /// Shared object created by the stream creator.
-    /// Viewers join to receive a StreamSession.
     public struct Stream has key, store {
         id:                UID,
         creator:           address,
-        /// USDC microunits a viewer must pay to join
+        /// v11: vessel_id for cross-primitive reputation attribution.
+        /// Indexer keys Stream earnings to this Vessel.
+        vessel_id:         ID,
         price_per_session: u64,
-        /// How long each session is valid for in milliseconds
         duration_ms:       u64,
-        /// Payment model: 0=PER_VIEW, 1=PER_MINUTE, 2=SUBSCRIPTION
         payment_type:      u8,
         state:             u8,
         created_at:        u64,
@@ -57,15 +51,11 @@ module axiom_tide::stream {
         session_count:     u64,
     }
 
-    /// Owned object transferred to the viewer when they join a stream.
-    /// verify() checks this object against the clock to confirm active access.
     public struct StreamSession has key, store {
         id:         UID,
         stream_id:  ID,
         viewer:     address,
-        /// Total USDC microunits paid to join
         paid:       u64,
-        /// Timestamp (ms) after which this session is no longer valid
         expires_at: u64,
         joined_at:  u64,
     }
@@ -75,6 +65,7 @@ module axiom_tide::stream {
     public struct StreamCreated has copy, drop {
         stream_id:         address,
         creator:           address,
+        vessel_id:         address,   // v11: added for indexer attribution
         price_per_session: u64,
         duration_ms:       u64,
         payment_type:      u8,
@@ -93,25 +84,19 @@ module axiom_tide::stream {
     public struct StreamEnded has copy, drop {
         stream_id:     address,
         creator:       address,
+        vessel_id:     address,   // v11: for indexer completeness
         total_earned:  u64,
         session_count: u64,
         ended_at:      u64,
         vod_chest_id:  Option<ID>,
     }
 
-    // ─── Public entry points ──────────────────────────────────────────────────
+    // ─── create() — v11: add vessel_id ────────────────────────────────────────
 
-    /// Create a new Stream.
-    ///
-    /// Creator pays a $0.05 open fee to Abyss.
-    /// The stream becomes a shared object — any viewer may join.
-    ///
-    /// price_per_session: USDC microunits per viewer session (min $0.01)
-    /// duration_ms:       how long each StreamSession is valid after join
-    /// payment_type:      0=PER_VIEW, 1=PER_MINUTE, 2=SUBSCRIPTION
     public fun create(
         fee_coin:          Coin<USDC>,
         abyss:             &mut Abyss,
+        vessel_id:         ID,          // v11: new — publisher's Vessel for attribution
         price_per_session: u64,
         duration_ms:       u64,
         payment_type:      u8,
@@ -129,6 +114,7 @@ module axiom_tide::stream {
         let stream = Stream {
             id:                object::new(ctx),
             creator,
+            vessel_id,
             price_per_session,
             duration_ms,
             payment_type,
@@ -141,6 +127,7 @@ module axiom_tide::stream {
         event::emit(StreamCreated {
             stream_id:         object::id_to_address(&object::id(&stream)),
             creator,
+            vessel_id:         object::id_to_address(&vessel_id),   // v11
             price_per_session,
             duration_ms,
             payment_type,
@@ -150,11 +137,6 @@ module axiom_tide::stream {
         transfer::share_object(stream);
     }
 
-    /// Join a live stream.
-    ///
-    /// Viewer pays price_per_session. Creator receives 97%, Abyss 3%.
-    /// A StreamSession (owned object) is transferred to the viewer.
-    /// The session is valid for stream.duration_ms milliseconds from now.
     public fun join(
         stream:   &mut Stream,
         fee_coin: Coin<USDC>,
@@ -164,14 +146,13 @@ module axiom_tide::stream {
     ) {
         assert!(stream.state == STATE_LIVE, E_STREAM_CLOSED);
 
-        let paid   = coin::value(&fee_coin);
+        let paid       = coin::value(&fee_coin);
         assert!(paid >= stream.price_per_session, E_INSUFFICIENT_FEE);
 
         let viewer     = tx_context::sender(ctx);
         let now        = clock::timestamp_ms(clock);
         let expires_at = now + stream.duration_ms;
 
-        // Split: 3% to protocol Abyss, 97% to creator
         let protocol_cut  = (paid * PROTOCOL_BPS) / 10_000;
         let mut coin_mut  = fee_coin;
         let protocol_coin = coin::split(&mut coin_mut, protocol_cut, ctx);
@@ -202,22 +183,10 @@ module axiom_tide::stream {
         transfer::transfer(session, viewer);
     }
 
-    /// Verify a viewer's StreamSession is still valid.
-    ///
-    /// Pure view — no state changes. Returns true if the session
-    /// has not yet expired according to the current clock timestamp.
-    public fun verify(
-        session: &StreamSession,
-        clock:   &Clock,
-    ): bool {
+    public fun verify(session: &StreamSession, clock: &Clock): bool {
         clock::timestamp_ms(clock) < session.expires_at
     }
 
-    /// End a stream.
-    ///
-    /// Only the creator may call this. Sets state to CLOSED.
-    /// Optionally links a VOD Chest ID so viewers can find the recording.
-    /// Emits StreamEnded with lifetime stats.
     public fun end(
         stream:       &mut Stream,
         vod_chest_id: Option<ID>,
@@ -232,6 +201,7 @@ module axiom_tide::stream {
         event::emit(StreamEnded {
             stream_id:     object::id_to_address(&object::id(stream)),
             creator:       stream.creator,
+            vessel_id:     object::id_to_address(&stream.vessel_id),   // v11
             total_earned:  stream.total_earned,
             session_count: stream.session_count,
             ended_at:      clock::timestamp_ms(clock),
@@ -241,6 +211,7 @@ module axiom_tide::stream {
 
     // ─── View helpers ─────────────────────────────────────────────────────────
     public fun creator(s: &Stream):           address { s.creator }
+    public fun vessel_id(s: &Stream):         ID      { s.vessel_id }   // v11
     public fun price_per_session(s: &Stream): u64     { s.price_per_session }
     public fun duration_ms(s: &Stream):       u64     { s.duration_ms }
     public fun payment_type(s: &Stream):      u8      { s.payment_type }
@@ -254,9 +225,9 @@ module axiom_tide::stream {
     public fun session_paid(ss: &StreamSession):      u64     { ss.paid }
     public fun session_expires_at(ss: &StreamSession): u64    { ss.expires_at }
 
-    public fun payment_per_view():    u8  { PAYMENT_PER_VIEW    }
-    public fun payment_per_minute():  u8  { PAYMENT_PER_MINUTE  }
-    public fun payment_subscription(): u8 { PAYMENT_SUBSCRIPTION }
-    public fun fee_stream_create():   u64 { FEE_STREAM_CREATE   }
-    public fun min_session_price():   u64 { MIN_SESSION_PRICE   }
+    public fun payment_per_view():     u8  { PAYMENT_PER_VIEW }
+    public fun payment_per_minute():   u8  { PAYMENT_PER_MINUTE }
+    public fun payment_subscription(): u8  { PAYMENT_SUBSCRIPTION }
+    public fun fee_stream_create():    u64 { FEE_STREAM_CREATE }
+    public fun min_session_price():    u64 { MIN_SESSION_PRICE }
 }

--- a/protocol/sources/vessel.move
+++ b/protocol/sources/vessel.move
@@ -1,8 +1,9 @@
-/// AXIOM TIDE PROTOCOL · v1.0.0
+/// AXIOM TIDE PROTOCOL · v11.0.0
 /// PRIMITIVE 2 OF 7 · VESSEL
 /// The identity. Mortal by design. Holds no USDC.
 /// Ghost · Shadow · Open · fixed at launch.
 /// Temp or permanent. 1yr silence then sinks forever.
+/// v11: lighthouse_count added. record_lighthouse() is owner-gated.
 /// Copyright © 2026 Axiom Tide LLC · axiomtide.com
 module axiom_tide::vessel {
     use sui::object::{Self, UID, ID};
@@ -23,15 +24,18 @@ module axiom_tide::vessel {
     const LIFESPAN_MS: u64 = 365 * 24 * 60 * 60 * 1000;
 
     public struct Vessel has key, store {
-        id:              UID,
-        harbor_id:       ID,
-        owner:           address,
-        tier:            u8,
-        created_at:      u64,
-        last_cast:       u64,
-        cast_count:      u64,
-        active_dock:     address,
-        burn_after_cast: bool,
+        id:               UID,
+        harbor_id:        ID,
+        owner:            address,
+        tier:             u8,
+        created_at:       u64,
+        last_cast:        u64,
+        cast_count:       u64,
+        active_dock:      address,
+        burn_after_cast:  bool,
+        /// v11: incremented by record_lighthouse() when a Cast published
+        /// by this Vessel earns Lighthouse status.
+        lighthouse_count: u64,
     }
 
     public struct VesselCap has key, store {
@@ -75,6 +79,13 @@ module axiom_tide::vessel {
         undocked_at: u64,
     }
 
+    /// v11: emitted when a Lighthouse is acknowledged on this Vessel.
+    public struct VesselLighthouseEarned has copy, drop {
+        vessel_id:        address,
+        lighthouse_count: u64,
+        earned_at:        u64,
+    }
+
     public fun launch(
         harbor_id:       ID,
         tier:            u8,
@@ -89,15 +100,16 @@ module axiom_tide::vessel {
         let owner = tx_context::sender(ctx);
         let now   = clock::timestamp_ms(clock);
         let vessel = Vessel {
-            id:              object::new(ctx),
+            id:               object::new(ctx),
             harbor_id,
             owner,
             tier,
-            created_at:      now,
-            last_cast:       now,
-            cast_count:      0,
-            active_dock:     @0x0,
+            created_at:       now,
+            last_cast:        now,
+            cast_count:       0,
+            active_dock:      @0x0,
             burn_after_cast,
+            lighthouse_count: 0,   // v11
         };
         let vessel_id   = object::id(&vessel);
         let vessel_addr = object::id_to_address(&vessel_id);
@@ -119,6 +131,9 @@ module axiom_tide::vessel {
         cap
     }
 
+    /// Increment cast_count and refresh the liveness timer.
+    /// Called internally by cast::sound() — not directly by publishers anymore.
+    /// Returns burn_after_cast so the SDK can sink the Vessel after sound().
     public fun touch(
         vessel: &mut Vessel,
         cap:    &VesselCap,
@@ -136,6 +151,23 @@ module axiom_tide::vessel {
             expires_at: now + LIFESPAN_MS,
         });
         vessel.burn_after_cast
+    }
+
+    /// v11: Acknowledge that a Cast published by this Vessel earned Lighthouse status.
+    /// Owner-gated via VesselCap. Called by lighthouse::raise() after it has already
+    /// verified that cast::vessel_id(cast) == object::id(vessel).
+    public fun record_lighthouse(
+        vessel: &mut Vessel,
+        cap:    &VesselCap,
+        clock:  &Clock,
+    ) {
+        assert!(cap.vessel_id == object::id(vessel), E_NOT_OWNER);
+        vessel.lighthouse_count = vessel.lighthouse_count + 1;
+        event::emit(VesselLighthouseEarned {
+            vessel_id:        object::id_to_address(&object::id(vessel)),
+            lighthouse_count: vessel.lighthouse_count,
+            earned_at:        clock::timestamp_ms(clock),
+        });
     }
 
     public fun enter_dock(
@@ -183,9 +215,9 @@ module axiom_tide::vessel {
         let now         = clock::timestamp_ms(clock);
         let vessel_addr = object::id_to_address(&object::id(&vessel));
         let casts       = vessel.cast_count;
-        let Vessel { id, harbor_id:_, owner:_, tier:_,
-                     created_at:_, last_cast:_, cast_count:_,
-                     active_dock:_, burn_after_cast:_ } = vessel;
+        let Vessel { id, harbor_id:_, owner:_, tier:_, created_at:_,
+                     last_cast:_, cast_count:_, active_dock:_,
+                     burn_after_cast:_, lighthouse_count:_ } = vessel;
         let VesselCap { id: cap_id, vessel_id:_, harbor_id:_,
                         owner:_, tier:_ } = cap;
         object::delete(id);
@@ -207,14 +239,18 @@ module axiom_tide::vessel {
     }
 
     public fun in_dock(vessel: &Vessel): bool { vessel.active_dock != @0x0 }
-    public fun tier(v: &Vessel):             u8      { v.tier }
-    public fun owner(v: &Vessel):            address { v.owner }
-    public fun harbor_id(v: &Vessel):        ID      { v.harbor_id }
-    public fun cast_count(v: &Vessel):       u64     { v.cast_count }
-    public fun last_cast(v: &Vessel):        u64     { v.last_cast }
-    public fun expires_at(v: &Vessel):       u64     { v.last_cast + LIFESPAN_MS }
-    public fun active_dock(v: &Vessel):      address { v.active_dock }
-    public fun burn_after_cast(v: &Vessel):  bool    { v.burn_after_cast }
+
+    // ─── View helpers ─────────────────────────────────────────────────────────
+    public fun tier(v: &Vessel):              u8      { v.tier }
+    public fun owner(v: &Vessel):             address { v.owner }
+    public fun harbor_id(v: &Vessel):         ID      { v.harbor_id }
+    public fun cast_count(v: &Vessel):        u64     { v.cast_count }
+    public fun last_cast(v: &Vessel):         u64     { v.last_cast }
+    public fun created_at(v: &Vessel):        u64     { v.created_at }
+    public fun expires_at(v: &Vessel):        u64     { v.last_cast + LIFESPAN_MS }
+    public fun active_dock(v: &Vessel):       address { v.active_dock }
+    public fun burn_after_cast(v: &Vessel):   bool    { v.burn_after_cast }
+    public fun lighthouse_count(v: &Vessel):  u64     { v.lighthouse_count }  // v11
     public fun ghost():  u8 { GHOST }
     public fun shadow(): u8 { SHADOW }
     public fun open():   u8 { OPEN }


### PR DESCRIPTION
## v11: Vessel Reputation + Lighthouse Registry

### Bug Fixes (shipped first)

**BUG-4:** `cast::sound()` never enforced `vessel::touch()`. `Vessel.cast_count` was silently incorrect — any reputation ratio built on it was built on sand.
- **Fix:** `sound()` now takes `&mut Vessel` + `&VesselCap`. Calls `touch()` internally. `vessel_id` and `vessel_tier` derived from the object, not trusted from caller.

**BUG-5:** `lighthouse::raise()` took all fields as raw values with zero validation. Anyone could fabricate a Lighthouse object with any cast_id/vessel_id.
- **Fix:** `raise()` now takes `&Cast`. Asserts `cast::is_lighthouse(cast)` on-chain. All fields derived from the Cast. Publisher-only (requires Vessel + VesselCap). `lighthouse_count` increment is protocol-enforced.

### New Modules

**`config.move`** — `ProtocolConfig` shared object
- Dynamic Lighthouse threshold: `max(1000, lh_count × 100)`
- Monotonic ratchet — threshold only increases
- Permissionless `recalibrate(config, drift)` — anyone can call it

**`registry.move`** — `LighthouseRegistry` shared object
- `Table<ID, LighthouseEntry>` keyed by `cast_id`
- O(1) `contains()` and `lookup()` — composable from any contract
- Atomically populated by `lighthouse::raise()`
- `last_visit_at` updated by `lighthouse::visit()` for recency filtering

### Protocol Changes

| Module | Change |
|--------|--------|
| `vessel.move` | +`lighthouse_count: u64`, +`record_lighthouse()` |
| `cast.move` | +`lighthouse_path` on Cast, +`vessel_id` in `CastSounded` event, `read()` takes `&ProtocolConfig` |
| `lighthouse.move` | `raise()` fully validated, `visit()` updates registry |
| `stream.move` | +`vessel_id` on Stream + `StreamCreated` event |

### Dependency Graph (no cycles)
```
abyss, drift, vessel, registry  ← no axiom_tide deps
config  ← drift
cast    ← abyss, vessel, config
lighthouse ← cast, vessel, registry, drift
stream  ← abyss
```

### Build
```
sui move build → BUILD_SUCCESS (warnings only)
```

### SDK Impact
conk-sdk v0.4.0 required. Breaking changes:
- `cast.sound()`: pass `vessel` + `vesselCap` objects
- `cast.read()`: pass `protocolConfig` shared object
- `lighthouse.raise()`: pass `cast`, `vessel`, `vesselCap`, `registry`, `drift`
- `stream.create()`: pass `vesselId`

New shared object IDs needed in SDK config after deploy:
- `PROTOCOL_CONFIG_ID`
- `LIGHTHOUSE_REGISTRY_ID`